### PR TITLE
Fix Index Issue for Format String & Add Culture Info When Need to Format

### DIFF
--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -190,6 +190,7 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
                         i++; // Move past '{'
                         int index = 0;
                         bool hasIndex = false;
+
                         // Parse index
                         while (i < len && char.IsDigit(format[i]))
                         {
@@ -197,6 +198,7 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
                             index = index * 10 + (format[i] - '0');
                             i++;
                         }
+
                         if (!hasIndex)
                         {
                             // Skip invalid format item
@@ -210,8 +212,25 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
                             }
                             continue;
                         }
-                        // Check for colon to parse format
+
+                        // Check for alignment (comma followed by optional sign and digits)
+                        if (i < len && format[i] == ',')
+                        {
+                            i++; // Skip comma and optional sign
+                            if (i < len && (format[i] == '+' || format[i] == '-'))
+                            {
+                                i++;
+                            }
+                            // Skip digits
+                            while (i < len && char.IsDigit(format[i]))
+                            {
+                                i++;
+                            }
+                        }
+
                         string formatPart = null;
+
+                        // Check for format (after colon)
                         if (i < len && format[i] == ':')
                         {
                             i++; // Move past ':'
@@ -243,6 +262,7 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
                                 i++; // Move past '}'
                             }
                         }
+
                         parameters[index] = formatPart;
                         if (index > maxIndex)
                         {
@@ -255,11 +275,11 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
                     // Handle possible escaped '}}'
                     if (i + 1 < len && format[i + 1] == '}')
                     {
-                        i += 2;
+                        i += 2; // Skip escaped '}}'
                     }
                     else
                     {
-                        i++;
+                        i++; // Move past '}'
                     }
                 }
                 else
@@ -274,7 +294,7 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             {
                 return result;
             }
-            
+
             for (int idx = 0; idx <= maxIndex; idx++)
             {
                 var formatValue = parameters.TryGetValue(idx, out var value) ? value : null;

--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -620,19 +620,21 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
 
             if (isCoreAssembly)
             {
+                var getTranslation = "InternationalizationManager.Instance.GetTranslation";
                 sb.AppendLine(parameters.Count > 0
                     ? !ls.Format ? 
-                        $"string.Format(InternationalizationManager.Instance.GetTranslation(\"{ls.Key}\"){formatArgs});"
-                        : $"string.Format(System.Globalization.CultureInfo.CurrentCulture, InternationalizationManager.Instance.GetTranslation(\"{ls.Key}\"){formatArgs});"
-                    : $"InternationalizationManager.Instance.GetTranslation(\"{ls.Key}\");");
+                        $"string.Format({getTranslation}(\"{ls.Key}\"){formatArgs});"
+                        : $"string.Format(System.Globalization.CultureInfo.CurrentCulture, {getTranslation}(\"{ls.Key}\"){formatArgs});"
+                    : $"{getTranslation}(\"{ls.Key}\");");
             }
             else if (pluginInfo?.IsValid == true)
             {
+                var getTranslation = $"{pluginInfo.ContextAccessor}.API.GetTranslation";
                 sb.AppendLine(parameters.Count > 0
                     ? !ls.Format ? 
-                        $"string.Format({pluginInfo.ContextAccessor}.API.GetTranslation(\"{ls.Key}\"){formatArgs});"
-                        : $"string.Format(System.Globalization.CultureInfo.CurrentCulture, {pluginInfo.ContextAccessor}.API.GetTranslation(\"{ls.Key}\"){formatArgs});"
-                    : $"{pluginInfo.ContextAccessor}.API.GetTranslation(\"{ls.Key}\");");
+                        $"string.Format({getTranslation}(\"{ls.Key}\"){formatArgs});"
+                        : $"string.Format(System.Globalization.CultureInfo.CurrentCulture, {getTranslation}(\"{ls.Key}\"){formatArgs});"
+                    : $"{getTranslation}(\"{ls.Key}\");");
             }
             else
             {


### PR DESCRIPTION
# Fix Index Issue for Format String

If format string skips certain values, these missing data will not be generated. We should analyze format string first to get the max index.

# Add Culture Info When Need to Format

When format string needs to be formatted (like `{1:D}`), we should pass culture info so that it can parse string correctly.

# Test

The string resources are:
![image](https://github.com/user-attachments/assets/716b4941-fdbc-4ee5-8647-a8071c6e6911)

The generated codes are:
![Screenshot 2025-03-08 182826](https://github.com/user-attachments/assets/bc1ec719-c888-45f2-affb-1fc970e9cd22)
![Screenshot 2025-03-08 182835](https://github.com/user-attachments/assets/49de7b38-ff0a-40c7-ae00-e9901a2d33b7)