### PR TITLE
Add FLLUseDependencyInjection property group & Move all constants to Shared project

### DIFF
--- a/Flow.Launcher.Localization.Analyzers/Flow.Launcher.Localization.Analyzers.csproj
+++ b/Flow.Launcher.Localization.Analyzers/Flow.Launcher.Localization.Analyzers.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Flow.Launcher.Localization.Shared\Flow.Launcher.Localization.Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzerCodeFixProvider.cs
+++ b/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzerCodeFixProvider.cs
@@ -109,6 +109,5 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
             var newRoot = root.ReplaceNode(invocationExpr, newInnerInvocationExpr);
             return context.Document.WithSyntaxRoot(newRoot);
         }
-
     }
 }

--- a/Flow.Launcher.Localization.Shared/Constants.cs
+++ b/Flow.Launcher.Localization.Shared/Constants.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Flow.Launcher.Localization.Shared
+{
+    public static class Constants
+    {
+        public const string DefaultNamespace = "Flow.Launcher";
+        public const string ClassName = "Localize";
+        public const string PluginInterfaceName = "IPluginI18n";
+        public const string PluginContextTypeName = "PluginInitContext";
+        public const string SystemPrefixUri = "clr-namespace:System;assembly=mscorlib";
+        public const string XamlPrefixUri = "http://schemas.microsoft.com/winfx/2006/xaml";
+        public const string XamlTag = "String";
+        public const string KeyTag = "Key";
+
+        public static readonly Regex LanguagesXamlRegex = new Regex(@"\\Languages\\[^\\]+\.xaml$", RegexOptions.IgnoreCase);
+    }
+}

--- a/Flow.Launcher.Localization.Shared/Constants.cs
+++ b/Flow.Launcher.Localization.Shared/Constants.cs
@@ -11,7 +11,7 @@ namespace Flow.Launcher.Localization.Shared
         public const string SystemPrefixUri = "clr-namespace:System;assembly=mscorlib";
         public const string XamlPrefixUri = "http://schemas.microsoft.com/winfx/2006/xaml";
         public const string XamlTag = "String";
-        public const string KeyTag = "Key";
+        public const string KeyAttribute = "Key";
 
         public static readonly Regex LanguagesXamlRegex = new Regex(@"\\Languages\\[^\\]+\.xaml$", RegexOptions.IgnoreCase);
     }

--- a/Flow.Launcher.Localization.Shared/Flow.Launcher.Localization.Shared.csproj
+++ b/Flow.Launcher.Localization.Shared/Flow.Launcher.Localization.Shared.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Version>0.0.1</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <RootNamespace>Flow.Launcher.Localization.Shared</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
+  </ItemGroup>
+
+</Project>

--- a/Flow.Launcher.Localization.Shared/Helper.cs
+++ b/Flow.Launcher.Localization.Shared/Helper.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Flow.Launcher.Localization.Shared
+{
+    public static class Helper
+    {
+        public static bool GetFLLUseDependencyInjection(this AnalyzerConfigOptionsProvider configOptions)
+        {
+            if (!configOptions.GlobalOptions.TryGetValue("build_property.FLLUseDependencyInjection", out var result) ||
+                !bool.TryParse(result, out var useDI))
+            {
+                return false; // Default to false
+            }
+            return useDI;
+        }
+    }
+}

--- a/Flow.Launcher.Localization.SourceGenerators/Flow.Launcher.Localization.SourceGenerators.csproj
+++ b/Flow.Launcher.Localization.SourceGenerators/Flow.Launcher.Localization.SourceGenerators.csproj
@@ -14,5 +14,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Flow.Launcher.Localization.Shared\Flow.Launcher.Localization.Shared.csproj" />
+  </ItemGroup>
   
 </Project>

--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -182,7 +182,7 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
                     return _emptyLocalizableStrings;
                 }
 
-                var key = element.Attribute(xNs + Constants.KeyTag)?.Value; // "Key" attribute in xaml namespace
+                var key = element.Attribute(xNs + Constants.KeyAttribute)?.Value; // "Key" attribute in xaml namespace
                 var value = element.Value;
                 var comment = element.PreviousNode as XComment;
 

--- a/Flow.Launcher.Localization.slnx
+++ b/Flow.Launcher.Localization.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Project Path="Flow.Launcher.Localization.Analyzers/Flow.Launcher.Localization.Analyzers.csproj" />
+  <Project Path="Flow.Launcher.Localization.Shared/Flow.Launcher.Localization.Shared.csproj" />
   <Project Path="Flow.Launcher.Localization.SourceGenerators/Flow.Launcher.Localization.SourceGenerators.csproj" />
   <Project Path="Flow.Launcher.Localization/Flow.Launcher.Localization.csproj" />
 </Solution>

--- a/Flow.Launcher.Localization/Flow.Launcher.Localization.csproj
+++ b/Flow.Launcher.Localization/Flow.Launcher.Localization.csproj
@@ -40,6 +40,7 @@
       <PackagePath>analyzers/dotnet/cs</PackagePath>
       <Visible>false</Visible>
     </None>
+    <None Include="build\Flow.Launcher.Localization.props" Pack="true" PackagePath="build" />
   </ItemGroup>
 
 </Project>

--- a/Flow.Launcher.Localization/Flow.Launcher.Localization.csproj
+++ b/Flow.Launcher.Localization/Flow.Launcher.Localization.csproj
@@ -1,41 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Version>0.0.1</Version>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-        <RootNamespace>Flow.Launcher.Localization</RootNamespace>
+  <PropertyGroup>
+    <Version>0.0.1</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <RootNamespace>Flow.Launcher.Localization</RootNamespace>
 
-        <IncludeBuildOutput>false</IncludeBuildOutput>
-        <DevelopmentDependency>true</DevelopmentDependency>
-        <NoPackageAnalysis>true</NoPackageAnalysis>
-        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    </PropertyGroup>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference
-                Include="..\Flow.Launcher.Localization.Analyzers\Flow.Launcher.Localization.Analyzers.csproj"
-                PrivateAssets="All"
-        />
-        <ProjectReference
-                Include="..\Flow.Launcher.Localization.SourceGenerators\Flow.Launcher.Localization.SourceGenerators.csproj"
-                PrivateAssets="All"
-        />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Flow.Launcher.Localization.Analyzers\Flow.Launcher.Localization.Analyzers.csproj">
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Flow.Launcher.Localization.Shared\Flow.Launcher.Localization.Shared.csproj" >
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Flow.Launcher.Localization.SourceGenerators\Flow.Launcher.Localization.SourceGenerators.csproj">
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <None
-                Include="$(OutputPath)\Flow.Launcher.Localization.Analyzers.dll"
-                Pack="true"
-                PackagePath="analyzers/dotnet/cs"
-                Visible="false"
-        />
-        <None
-                Include="$(OutputPath)\Flow.Launcher.Localization.SourceGenerators.dll"
-                Pack="true"
-                PackagePath="analyzers/dotnet/cs"
-                Visible="false"
-        />
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="$(OutputPath)\Flow.Launcher.Localization.Analyzers.dll">
+      <Pack>true</Pack>
+      <PackagePath>analyzers/dotnet/cs</PackagePath>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(OutputPath)\Flow.Launcher.Localization.Shared.dll">
+      <Pack>true</Pack>
+      <PackagePath>analyzers/dotnet/cs</PackagePath>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(OutputPath)\Flow.Launcher.Localization.SourceGenerators.dll">
+      <Pack>true</Pack>
+      <PackagePath>analyzers/dotnet/cs</PackagePath>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/Flow.Launcher.Localization/build/Flow.Launcher.Localization.props
+++ b/Flow.Launcher.Localization/build/Flow.Launcher.Localization.props
@@ -1,0 +1,5 @@
+﻿<Project>
+    <ItemGroup>
+        <CompilerVisibleProperty Include="FLLUseDependencyInjection" />
+    </ItemGroup>
+</Project>

--- a/Flow.Launcher.Localization/build/Flow.Launcher.Localization.props
+++ b/Flow.Launcher.Localization/build/Flow.Launcher.Localization.props
@@ -1,5 +1,6 @@
 ﻿<Project>
     <ItemGroup>
         <CompilerVisibleProperty Include="FLLUseDependencyInjection" />
+        <AdditionalFiles Include="Languages\en.xaml" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
# Add FLLUseDependencyInjection property group

Since `InternationalizationManager.Instance` is on the way to be deprecated (https://github.com/Flow-Launcher/Flow.Launcher/pull/3276), we should move to `Ioc.Default.GetRequiredService`.

To let this can be used for not only core project, we should use property `FLLUseDependencyInjection` instead of core assembly check. The default value is `false`.

# Move all constants to Shared project

Improve code quality.

# Test

When we add these in the project

```
<!-- declare the property you want to access in your analyzer -->
<PropertyGroup>
  <FLLUseDependencyInjection>true</FLLUseDependencyInjection>
</PropertyGroup>
```

Source generator will use dependency injection to get translation

![image](https://github.com/user-attachments/assets/a1d1521a-31ae-42cc-ac25-0d551b1c3fef)

And you do not need to have `public static Context` in your main class. (Tested with no build issue & No warning)

![image](https://github.com/user-attachments/assets/acfa3992-36c3-4180-97ee-26c6292a6931)