### PR TITLE
Improve diagnostics

### DIFF
--- a/Flow.Launcher.Localization.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/Flow.Launcher.Localization.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -4,10 +4,9 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-FLSG0001 | Localization | Warning | FLSG0001_CouldNotFindResourceDictionaries
+FLSG0001 | Localization | Warning | FLSG0001_LocalizationKeyUnused
 FLSG0002 | Localization | Warning | FLSG0002_CouldNotFindPluginEntryClass
 FLSG0003 | Localization | Warning | FLSG0003_CouldNotFindContextProperty
 FLSG0004 | Localization | Warning | FLSG0004_ContextPropertyNotStatic
 FLSG0005 | Localization | Warning | FLSG0005_ContextPropertyIsPrivate
 FLSG0006 | Localization | Warning | FLSG0006_ContextPropertyIsProtected
-FLSG0007 | Localization | Warning | FLSG0007_LocalizationKeyUnused

--- a/Flow.Launcher.Localization.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/Flow.Launcher.Localization.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -4,9 +4,10 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-FLSG0001 | Localization | Warning | FLSG0001_LocalizationKeyUnused
+FLSG0001 | Localization | Warning | FLSG0001_CouldNotFindResourceDictionaries
 FLSG0002 | Localization | Warning | FLSG0002_CouldNotFindPluginEntryClass
 FLSG0003 | Localization | Warning | FLSG0003_CouldNotFindContextProperty
 FLSG0004 | Localization | Warning | FLSG0004_ContextPropertyNotStatic
 FLSG0005 | Localization | Warning | FLSG0005_ContextPropertyIsPrivate
 FLSG0006 | Localization | Warning | FLSG0006_ContextPropertyIsProtected
+FLSG0007 | Localization | Warning | FLSG0007_LocalizationKeyUnused

--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -84,6 +84,15 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             ImmutableArray<AdditionalText> AdditionalTexts) data)
         {
             var xamlFiles = data.AdditionalTexts;
+            if (xamlFiles.Length == 0)
+            {
+                spc.ReportDiagnostic(Diagnostic.Create(
+                    SourceGeneratorDiagnostics.CouldNotFindResourceDictionaries,
+                    Location.None
+                ));
+                return;
+            }
+
             var compilation = data.Item1.Compilation;
             var configOptions = data.Item1.Item1.ConfigOptionsProvider;
             var pluginClasses = data.Item1.Item1.Item1.PluginClassInfos;

--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -84,15 +84,6 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             ImmutableArray<AdditionalText> AdditionalTexts) data)
         {
             var xamlFiles = data.AdditionalTexts;
-            if (xamlFiles.Length == 0)
-            {
-                spc.ReportDiagnostic(Diagnostic.Create(
-                    SourceGeneratorDiagnostics.CouldNotFindResourceDictionaries,
-                    Location.None
-                ));
-                return;
-            }
-
             var compilation = data.Item1.Compilation;
             var configOptions = data.Item1.Item1.ConfigOptionsProvider;
             var pluginClasses = data.Item1.Item1.Item1.PluginClassInfos;

--- a/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
@@ -17,7 +17,7 @@ namespace Flow.Launcher.Localization.SourceGenerators
         public static readonly DiagnosticDescriptor CouldNotFindPluginEntryClass = new DiagnosticDescriptor(
             "FLSG0002",
             "Could not find the main class of plugin",
-            $"Could not find the main class of your plugin. It must implement {Constants.PluginInterfaceName}.",
+            $"Could not find the main class of your plugin. It must implement `{Constants.PluginInterfaceName}`.",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true
@@ -26,7 +26,7 @@ namespace Flow.Launcher.Localization.SourceGenerators
         public static readonly DiagnosticDescriptor CouldNotFindContextProperty = new DiagnosticDescriptor(
             "FLSG0003",
             "Could not find plugin context property",
-            $"Could not find a property of type {Constants.PluginContextTypeName} in {{0}}. It must be a public static or internal static property of the main class of your plugin.",
+            $"Could not find a property of type `{Constants.PluginContextTypeName}` in `{{0}}`. It must be a public static or internal static property of the main class of your plugin.",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true
@@ -35,7 +35,7 @@ namespace Flow.Launcher.Localization.SourceGenerators
         public static readonly DiagnosticDescriptor ContextPropertyNotStatic = new DiagnosticDescriptor(
             "FLSG0004",
             "Plugin context property is not static",
-            "Context property {0} is not static. It must be static.",
+            "Context property `{0}` is not static. It must be static.",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true
@@ -44,7 +44,7 @@ namespace Flow.Launcher.Localization.SourceGenerators
         public static readonly DiagnosticDescriptor ContextPropertyIsPrivate = new DiagnosticDescriptor(
             "FLSG0005",
             "Plugin context property is private",
-            "Context property {0} is private. It must be either internal or public.",
+            "Context property `{0}` is private. It must be either internal or public.",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true
@@ -53,7 +53,7 @@ namespace Flow.Launcher.Localization.SourceGenerators
         public static readonly DiagnosticDescriptor ContextPropertyIsProtected = new DiagnosticDescriptor(
             "FLSG0006",
             "Plugin context property is protected",
-            "Context property {0} is protected. It must be either internal or public.",
+            "Context property `{0}` is protected. It must be either internal or public.",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true
@@ -62,7 +62,7 @@ namespace Flow.Launcher.Localization.SourceGenerators
         public static readonly DiagnosticDescriptor LocalizationKeyUnused = new DiagnosticDescriptor(
             "FLSG0007",
             "Localization key is unused",
-            $"Method '{Constants.ClassName}.{{0}}' is never used",
+            $"Method `{Constants.ClassName}.{{0}}` is never used",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true

--- a/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
@@ -5,10 +5,10 @@ namespace Flow.Launcher.Localization.SourceGenerators
 {
     public static class SourceGeneratorDiagnostics
     {
-        public static readonly DiagnosticDescriptor LocalizationKeyUnused = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor CouldNotFindResourceDictionaries = new DiagnosticDescriptor(
             "FLSG0001",
-            "Localization key is unused",
-            $"Method `{Constants.ClassName}.{{0}}` is never used",
+            "Could not find resource dictionaries",
+            "Could not find resource dictionaries. There must be a file named [LANG].xaml file (for example, en.xaml), and it must be specified in <AdditionalFiles /> in your .csproj file.",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true
@@ -54,6 +54,15 @@ namespace Flow.Launcher.Localization.SourceGenerators
             "FLSG0006",
             "Plugin context property is protected",
             "Context property `{0}` is protected. It must be either internal or public.",
+            "Localization",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true
+        );
+
+        public static readonly DiagnosticDescriptor LocalizationKeyUnused = new DiagnosticDescriptor(
+            "FLSG0007",
+            "Localization key is unused",
+            $"Method `{Constants.ClassName}.{{0}}` is never used",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true

--- a/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
@@ -5,10 +5,10 @@ namespace Flow.Launcher.Localization.SourceGenerators
 {
     public static class SourceGeneratorDiagnostics
     {
-        public static readonly DiagnosticDescriptor CouldNotFindResourceDictionaries = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor LocalizationKeyUnused = new DiagnosticDescriptor(
             "FLSG0001",
-            "Could not find resource dictionaries",
-            "Could not find resource dictionaries. There must be a file named [LANG].xaml file (for example, en.xaml), and it must be specified in <AdditionalFiles /> in your .csproj file.",
+            "Localization key is unused",
+            $"Method `{Constants.ClassName}.{{0}}` is never used",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true
@@ -54,15 +54,6 @@ namespace Flow.Launcher.Localization.SourceGenerators
             "FLSG0006",
             "Plugin context property is protected",
             "Context property `{0}` is protected. It must be either internal or public.",
-            "Localization",
-            DiagnosticSeverity.Warning,
-            isEnabledByDefault: true
-        );
-
-        public static readonly DiagnosticDescriptor LocalizationKeyUnused = new DiagnosticDescriptor(
-            "FLSG0007",
-            "Localization key is unused",
-            $"Method `{Constants.ClassName}.{{0}}` is never used",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true

--- a/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/SourceGeneratorDiagnostics.cs
@@ -8,7 +8,7 @@ namespace Flow.Launcher.Localization.SourceGenerators
         public static readonly DiagnosticDescriptor CouldNotFindResourceDictionaries = new DiagnosticDescriptor(
             "FLSG0001",
             "Could not find resource dictionaries",
-            "Could not find resource dictionaries. There must be a file named [LANG].xaml file (for example, en.xaml), and it must be specified in <AdditionalFiles /> in your .csproj file.",
+            "Could not find resource dictionaries. There must be a `en.xaml` file under `Language` folder.",
             "Localization",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true


### PR DESCRIPTION
# 1. Support CouldNotFindPluginEntryClass & CouldNotFindContextProperty diagonostics

![Screenshot 2025-03-10 203203](https://github.com/user-attachments/assets/70279529-00b2-4aa3-9228-228c754662cc)

![Screenshot 2025-03-10 203257](https://github.com/user-attachments/assets/c1421a53-084a-4e23-ab76-92deca047adb)

![Screenshot 2025-03-10 203340](https://github.com/user-attachments/assets/d7f1a1d9-eb4c-4be3-b42a-3affdaa14081)

# 2. Improve diagnostics display

Use "`" to wrap class & method names to let users know it is from codes.