### PR TITLE
Move PluginClassInfo & Add code regions

### DIFF
--- a/Flow.Launcher.Localization.Analyzers/Localize/ContextAvailabilityAnalyzer.cs
+++ b/Flow.Launcher.Localization.Analyzers/Localize/ContextAvailabilityAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         AnalyzerDiagnostics.ContextIsNotStatic,
-                        pluginClassInfo.CodeFixLocatioin
+                        pluginClassInfo.CodeFixLocation
                     ));
                     return;
                 }
@@ -66,7 +66,7 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         AnalyzerDiagnostics.ContextAccessIsTooRestrictive,
-                        pluginClassInfo.CodeFixLocatioin
+                        pluginClassInfo.CodeFixLocation
                     ));
                     return;
                 }

--- a/Flow.Launcher.Localization.Analyzers/Localize/ContextAvailabilityAnalyzer.cs
+++ b/Flow.Launcher.Localization.Analyzers/Localize/ContextAvailabilityAnalyzer.cs
@@ -11,6 +11,8 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class ContextAvailabilityAnalyzer : DiagnosticAnalyzer
     {
+        #region DiagnosticAnalyzer
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
             AnalyzerDiagnostics.ContextIsAField,
             AnalyzerDiagnostics.ContextIsNotStatic,
@@ -25,47 +27,55 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
             context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ClassDeclaration);
         }
 
+        #endregion
+
+        #region Analyze Methods
+
         private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var configOptions = context.Options.AnalyzerConfigOptionsProvider;
             var useDI = configOptions.GetFLLUseDependencyInjection();
-
-            // If we use dependency injection, we don't need to check for this context property
-            if (useDI) return;
-
-            var classDeclaration = (ClassDeclarationSyntax)context.Node;
-            var semanticModel = context.SemanticModel;
-            var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
-
-            if (!IsPluginEntryClass(classSymbol)) return;
-
-            var contextProperty = classDeclaration.Members.OfType<PropertyDeclarationSyntax>()
-                .Select(p => semanticModel.GetDeclaredSymbol(p))
-                .FirstOrDefault(p => p?.Type.Name is Constants.PluginContextTypeName);
-
-            if (contextProperty != null)
+            if (useDI)
             {
-                if (!contextProperty.IsStatic)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        AnalyzerDiagnostics.ContextIsNotStatic,
-                        contextProperty.DeclaringSyntaxReferences[0].GetSyntax().GetLocation()
-                    ));
-                    return;
-                }
-
-                if (contextProperty.DeclaredAccessibility is Accessibility.Private || contextProperty.DeclaredAccessibility is Accessibility.Protected)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        AnalyzerDiagnostics.ContextAccessIsTooRestrictive,
-                        contextProperty.DeclaringSyntaxReferences[0].GetSyntax().GetLocation()
-                    ));
-                    return;
-                }
-
+                // If we use dependency injection, we don't need to check for this context property
                 return;
             }
 
+            var classDeclaration = (ClassDeclarationSyntax)context.Node;
+            var semanticModel = context.SemanticModel;
+            var pluginClassInfo = Helper.GetPluginClassInfo(classDeclaration, semanticModel, context.CancellationToken);
+            if (pluginClassInfo == null)
+            {
+                // Cannot find class that implements IPluginI18n
+                return;
+            }
+
+            // Context property is found, check if it's a valid property
+            if (pluginClassInfo.PropertyName != null)
+            {
+                if (!pluginClassInfo.IsStatic)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        AnalyzerDiagnostics.ContextIsNotStatic,
+                        pluginClassInfo.CodeFixLocatioin
+                    ));
+                    return;
+                }
+
+                if (pluginClassInfo.IsPrivate || pluginClassInfo.IsProtected)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        AnalyzerDiagnostics.ContextAccessIsTooRestrictive,
+                        pluginClassInfo.CodeFixLocatioin
+                    ));
+                    return;
+                }
+
+                // If the context property is valid, we don't need to check for anything else
+                return;
+            }
+
+            // Context property is not found, check if it's declared as a field
             var fieldDeclaration = classDeclaration.Members
                 .OfType<FieldDeclarationSyntax>()
                 .SelectMany(f => f.Declaration.Variables)
@@ -75,7 +85,6 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
                 ?.DeclaringSyntaxReferences[0]
                 .GetSyntax()
                 .FirstAncestorOrSelf<FieldDeclarationSyntax>();
-
             if (parentSyntax != null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
@@ -85,13 +94,13 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
                 return;
             }
 
+            // Context property is not found, report an error
             context.ReportDiagnostic(Diagnostic.Create(
                 AnalyzerDiagnostics.ContextIsNotDeclared,
                 classDeclaration.Identifier.GetLocation()
             ));
         }
 
-        private static bool IsPluginEntryClass(INamedTypeSymbol namedTypeSymbol) =>
-            namedTypeSymbol?.Interfaces.Any(i => i.Name == Constants.PluginInterfaceName) ?? false;
+        #endregion
     }
 }

--- a/Flow.Launcher.Localization.Analyzers/Localize/ContextAvailabilityAnalyzerCodeFixProvider.cs
+++ b/Flow.Launcher.Localization.Analyzers/Localize/ContextAvailabilityAnalyzerCodeFixProvider.cs
@@ -17,6 +17,8 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ContextAvailabilityAnalyzerCodeFixProvider)), Shared]
     public class ContextAvailabilityAnalyzerCodeFixProvider : CodeFixProvider
     {
+        #region CodeFixProvider
+
         public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
             AnalyzerDiagnostics.ContextIsAField.Id,
             AnalyzerDiagnostics.ContextIsNotStatic.Id,
@@ -82,21 +84,9 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
             }
         }
 
-        private static MemberDeclarationSyntax GetStaticContextPropertyDeclaration(string propertyName = "Context") =>
-            SyntaxFactory.ParseMemberDeclaration(
-                $"internal static {Constants.PluginContextTypeName} {propertyName} {{ get; private set; }} = null!;"
-            );
+        #endregion
 
-        private static Document GetFormattedDocument(CodeFixContext context, SyntaxNode root)
-        {
-            var formattedRoot = Formatter.Format(
-                root,
-                Formatter.Annotation,
-                context.Document.Project.Solution.Workspace
-            );
-
-            return context.Document.WithSyntaxRoot(formattedRoot);
-        }
+        #region Fix Methods
 
         private static Document FixContextNotDeclared(CodeFixContext context, SyntaxNode root, TextSpan diagnosticSpan)
         {
@@ -160,6 +150,24 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
             return GetFormattedDocument(context, newRoot);
         }
 
+        #region Utils
+
+        private static MemberDeclarationSyntax GetStaticContextPropertyDeclaration(string propertyName = "Context") =>
+            SyntaxFactory.ParseMemberDeclaration(
+                $"internal static {Constants.PluginContextTypeName} {propertyName} {{ get; private set; }} = null!;"
+            );
+
+        private static Document GetFormattedDocument(CodeFixContext context, SyntaxNode root)
+        {
+            var formattedRoot = Formatter.Format(
+                root,
+                Formatter.Annotation,
+                context.Document.Project.Solution.Workspace
+            );
+
+            return context.Document.WithSyntaxRoot(formattedRoot);
+        }
+
         private static PropertyDeclarationSyntax FixRestrictivePropertyModifiers(PropertyDeclarationSyntax propertyDeclaration)
         {
             var newModifiers = SyntaxFactory.TokenList();
@@ -185,5 +193,9 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
                 ?.AncestorsAndSelf()
                 .OfType<T>()
                 .First();
+
+        #endregion
+
+        #endregion
     }
 }

--- a/Flow.Launcher.Localization.Shared/Classes.cs
+++ b/Flow.Launcher.Localization.Shared/Classes.cs
@@ -10,12 +10,12 @@ namespace Flow.Launcher.Localization.Shared
         public bool IsStatic { get; }
         public bool IsPrivate { get; }
         public bool IsProtected { get; }
-        public Location CodeFixLocatioin { get; }
+        public Location CodeFixLocation { get; }
 
         public string ContextAccessor => $"{ClassName}.{PropertyName}";
         public bool IsValid => PropertyName != null && IsStatic && (!IsPrivate) && (!IsProtected);
 
-        public PluginClassInfo(Location location, string className, string propertyName, bool isStatic, bool isPrivate, bool isProtected, Location codeFixLocatioin)
+        public PluginClassInfo(Location location, string className, string propertyName, bool isStatic, bool isPrivate, bool isProtected, Location codeFixLocation)
         {
             Location = location;
             ClassName = className;
@@ -23,7 +23,7 @@ namespace Flow.Launcher.Localization.Shared
             IsStatic = isStatic;
             IsPrivate = isPrivate;
             IsProtected = isProtected;
-            CodeFixLocatioin = codeFixLocatioin;
+            CodeFixLocation = codeFixLocation;
         }
     }
 }

--- a/Flow.Launcher.Localization.Shared/Classes.cs
+++ b/Flow.Launcher.Localization.Shared/Classes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Flow.Launcher.Localization.Shared
+{
+    public class PluginClassInfo
+    {
+        public Location Location { get; }
+        public string ClassName { get; }
+        public string PropertyName { get; }
+        public bool IsStatic { get; }
+        public bool IsPrivate { get; }
+        public bool IsProtected { get; }
+        public Location CodeFixLocatioin { get; }
+
+        public string ContextAccessor => $"{ClassName}.{PropertyName}";
+        public bool IsValid => PropertyName != null && IsStatic && (!IsPrivate) && (!IsProtected);
+
+        public PluginClassInfo(Location location, string className, string propertyName, bool isStatic, bool isPrivate, bool isProtected, Location codeFixLocatioin)
+        {
+            Location = location;
+            ClassName = className;
+            PropertyName = propertyName;
+            IsStatic = isStatic;
+            IsPrivate = isPrivate;
+            IsProtected = isProtected;
+            CodeFixLocatioin = codeFixLocatioin;
+        }
+    }
+}

--- a/Flow.Launcher.Localization.Shared/Flow.Launcher.Localization.Shared.csproj
+++ b/Flow.Launcher.Localization.Shared/Flow.Launcher.Localization.Shared.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
   </ItemGroup>
 
 </Project>

--- a/Flow.Launcher.Localization.Shared/Helper.cs
+++ b/Flow.Launcher.Localization.Shared/Helper.cs
@@ -1,9 +1,16 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Linq;
+using System.Threading;
 
 namespace Flow.Launcher.Localization.Shared
 {
     public static class Helper
     {
+        #region Build Properties
+
         public static bool GetFLLUseDependencyInjection(this AnalyzerConfigOptionsProvider configOptions)
         {
             if (!configOptions.GlobalOptions.TryGetValue("build_property.FLLUseDependencyInjection", out var result) ||
@@ -13,5 +20,66 @@ namespace Flow.Launcher.Localization.Shared
             }
             return useDI;
         }
+
+        #endregion
+
+        #region Plugin Class Info
+
+        /// <summary>
+        /// If cannot find the class that implements IPluginI18n, return null.
+        /// If cannot find the context property, return PluginClassInfo with null context property name.
+        /// </summary>
+        public static PluginClassInfo GetPluginClassInfo(ClassDeclarationSyntax classDecl, SemanticModel semanticModel, CancellationToken ct)
+        {
+            var classSymbol = semanticModel.GetDeclaredSymbol(classDecl, ct);
+            if (!IsPluginEntryClass(classSymbol))
+            {
+                // Cannot find class that implements IPluginI18n
+                return null;
+            }
+
+            var property = GetContextProperty(classDecl);
+            var location = GetLocation(semanticModel.SyntaxTree, classDecl);
+            if (property is null)
+            {
+                // Cannot find context
+                return new PluginClassInfo(location, classDecl.Identifier.Text, null, false, false, false, null);
+            }
+
+            var modifiers = property.Modifiers;
+            var codeFixLocation = GetCodeFixLocation(property, semanticModel);
+            return new PluginClassInfo(
+                location,
+                classDecl.Identifier.Text,
+                property.Identifier.Text,
+                modifiers.Any(SyntaxKind.StaticKeyword),
+                modifiers.Any(SyntaxKind.PrivateKeyword),
+                modifiers.Any(SyntaxKind.ProtectedKeyword),
+                codeFixLocation);
+        }
+
+        private static bool IsPluginEntryClass(INamedTypeSymbol namedTypeSymbol)
+        {
+            return namedTypeSymbol?.Interfaces.Any(i => i.Name == Constants.PluginInterfaceName) ?? false;
+        }
+
+        private static PropertyDeclarationSyntax GetContextProperty(ClassDeclarationSyntax classDecl)
+        {
+            return classDecl.Members
+                .OfType<PropertyDeclarationSyntax>()
+                .FirstOrDefault(p => p.Type.ToString() == Constants.PluginContextTypeName);
+        }
+
+        private static Location GetLocation(SyntaxTree syntaxTree, CSharpSyntaxNode classDeclaration)
+        {
+            return Location.Create(syntaxTree, classDeclaration.GetLocation().SourceSpan);
+        }
+
+        private static Location GetCodeFixLocation(PropertyDeclarationSyntax property, SemanticModel semanticModel)
+        {
+            return semanticModel.GetDeclaredSymbol(property).DeclaringSyntaxReferences[0].GetSyntax().GetLocation();
+        }
+
+        #endregion
     }
 }

--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Xml.Linq;
 using Flow.Launcher.Localization.Shared;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -57,7 +56,7 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             var pluginClasses = context.SyntaxProvider
                 .CreateSyntaxProvider(
                     predicate: (n, _) => n is ClassDeclarationSyntax,
-                    transform: GetPluginClassInfo)
+                    transform: (c, t) => Helper.GetPluginClassInfo((ClassDeclarationSyntax)c.Node, c.SemanticModel, t))
                 .Where(info => info != null)
                 .Collect();
 
@@ -428,35 +427,6 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
 
         #region Get Plugin Class Info
 
-        private static PluginClassInfo GetPluginClassInfo(GeneratorSyntaxContext context, CancellationToken ct)
-        {
-            var classDecl = (ClassDeclarationSyntax)context.Node;
-            var location = GetLocation(context.SemanticModel.SyntaxTree, classDecl);
-            if (!classDecl.BaseList?.Types.Any(t => t.Type.ToString() == Constants.PluginInterfaceName) ?? true)
-            {
-                // Cannot find class that implements IPluginI18n
-                return null;
-            }
-
-            var property = classDecl.Members
-                .OfType<PropertyDeclarationSyntax>()
-                .FirstOrDefault(p => p.Type.ToString() == Constants.PluginContextTypeName);
-            if (property is null)
-            {
-                // Cannot find context
-                return new PluginClassInfo(location, classDecl.Identifier.Text, null, false, false, false);
-            }
-
-            var modifiers = property.Modifiers;
-            return new PluginClassInfo(
-                location,
-                classDecl.Identifier.Text,
-                property.Identifier.Text,
-                modifiers.Any(SyntaxKind.StaticKeyword),
-                modifiers.Any(SyntaxKind.PrivateKeyword),
-                modifiers.Any(SyntaxKind.ProtectedKeyword));
-        }
-
         private static PluginClassInfo GetValidPluginInfo(
             ImmutableArray<PluginClassInfo> pluginClasses,
             SourceProductionContext context,
@@ -533,11 +503,6 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             }
 
             return null;
-        }
-
-        private static Location GetLocation(SyntaxTree syntaxTree, CSharpSyntaxNode classDeclaration)
-        {
-            return Location.Create(syntaxTree, classDeclaration.GetLocation().SourceSpan);
         }
 
         #endregion
@@ -769,29 +734,6 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
                 Value = value;
                 Summary = summary;
                 Params = @params;
-            }
-        }
-
-        public class PluginClassInfo
-        {
-            public Location Location { get; }
-            public string ClassName { get; }
-            public string PropertyName { get; }
-            public bool IsStatic { get; }
-            public bool IsPrivate { get; }
-            public bool IsProtected { get; }
-
-            public string ContextAccessor => $"{ClassName}.{PropertyName}";
-            public bool IsValid => PropertyName != null && IsStatic && (!IsPrivate) && (!IsProtected);
-
-            public PluginClassInfo(Location location, string className, string propertyName, bool isStatic, bool isPrivate, bool isProtected)
-            {
-                Location = location;
-                ClassName = className;
-                PropertyName = propertyName;
-                IsStatic = isStatic;
-                IsPrivate = isPrivate;
-                IsProtected = isProtected;
             }
         }
 


### PR DESCRIPTION
> [!IMPORTANT]
> I have thoroughly tested the generator diagnostics and code fixes related to the `PluginInitContext` and I believe them are ready to move to production.

# Move PluginClassInfo to Shared project

Let `ContextAvailabilityAnalyzer.cs` and `LocalizeSourceGenerator.cs` both use this class. Add `CodeFixLocation` property for code fix.

# Add regions

In `ContextAvailabilityAnalyzer.cs` and `ContextAvailabilityAnalyzerCodeFixProvider.cs` for code quality.

# Test

1. Source generator diagnostic FLSG0002 ~ FLSG0006 can work.
2. Code fixer diagnostic FLAN0002 ~ FLAN0005 can work.