### PR TITLE
Support string.Format culture info parameter analyzer & code fixer

### DIFF
--- a/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzer.cs
+++ b/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzer.cs
@@ -105,7 +105,7 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
             methodSymbol.ContainingType.ToDisplayString() == Constants.StringFormatTypeName;
 
         private static InvocationExpressionSyntax GetArgumentInvocationExpression(InvocationExpressionSyntax invocationExpr, int index) =>
-             invocationExpr.ArgumentList.Arguments[index].Expression as InvocationExpressionSyntax;
+            invocationExpr.ArgumentList.Arguments[index].Expression as InvocationExpressionSyntax;
 
         private static bool IsTranslateCall(SymbolInfo symbolInfo) =>
             symbolInfo.Symbol is IMethodSymbol innerMethodSymbol &&

--- a/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzerCodeFixProvider.cs
+++ b/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzerCodeFixProvider.cs
@@ -49,22 +49,38 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
         {
             var diagnosticSpan = diagnostic.Location.SourceSpan;
 
+            if (root is null) return context.Document;
+
             var invocationExpr = root
                 ?.FindToken(diagnosticSpan.Start).Parent
                 ?.AncestorsAndSelf()
                 .OfType<InvocationExpressionSyntax>()
-                .First();
+                .FirstOrDefault();
 
-            if (invocationExpr is null || root is null) return context.Document;
+            if (invocationExpr is null) return context.Document;
 
             var argumentList = invocationExpr.ArgumentList.Arguments;
-            var argument = argumentList.First().Expression;
 
-            if (GetTranslationKey(argument) is string translationKey)
-                return FixOldTranslationWithoutStringFormat(context, translationKey, root, invocationExpr);
+            // Loop through the arguments to find the translation key.
+            for (int i = 0; i < argumentList.Count; i++)
+            {
+                var argument = argumentList[i].Expression;
 
-            if (GetTranslationKeyFromInnerInvocation(argument) is string translationKeyInside)
-                return FixOldTranslationWithStringFormat(context, argumentList, translationKeyInside, root, invocationExpr);
+                // Case 1: The argument is a literal (direct GetTranslation("key"))
+                if (GetTranslationKey(argument) is string translationKey)
+                    return FixOldTranslationWithoutStringFormat(context, translationKey, root, invocationExpr);
+
+                // Case 2: The argument is itself an invocation (nested GetTranslation)
+                if (GetTranslationKeyFromInnerInvocation(argument) is string translationKeyInside)
+                {
+                    // If there are arguments following this translation call, treat as a Format call.
+                    if (i < argumentList.Count - 1)
+                        return FixOldTranslationWithStringFormat(context, argumentList, translationKeyInside, root, invocationExpr, i);
+
+                    // Otherwise, treat it as a direct translation call.
+                    return FixOldTranslationWithoutStringFormat(context, translationKeyInside, root, invocationExpr);
+                }
+            }
 
             return context.Document;
         }
@@ -94,7 +110,7 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
         private static string GetTranslationKeyFromInnerInvocation(ExpressionSyntax syntax)
         {
             if (syntax is InvocationExpressionSyntax invocationExpressionSyntax &&
-                invocationExpressionSyntax.ArgumentList.Arguments.Count is 1)
+                invocationExpressionSyntax.ArgumentList.Arguments.Count == 1)
             {
                 var firstArgument = invocationExpressionSyntax.ArgumentList.Arguments.First().Expression;
                 return GetTranslationKey(firstArgument);
@@ -107,9 +123,11 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
             SeparatedSyntaxList<ArgumentSyntax> argumentList,
             string translationKey2,
             SyntaxNode root,
-            InvocationExpressionSyntax invocationExpr)
+            InvocationExpressionSyntax invocationExpr,
+            int translationArgIndex)
         {
-            var newArguments = string.Join(", ", argumentList.Skip(1).Select(a => a.Expression));
+            // Skip all arguments before and including the translation call
+            var newArguments = string.Join(", ", argumentList.Skip(translationArgIndex + 1).Select(a => a.Expression));
             var newInnerInvocationExpr = SyntaxFactory.ParseExpression($"{Constants.ClassName}.{translationKey2}({newArguments})");
 
             var newRoot = root.ReplaceNode(invocationExpr, newInnerInvocationExpr);

--- a/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzerCodeFixProvider.cs
+++ b/Flow.Launcher.Localization.Analyzers/Localize/OldGetTranslateAnalyzerCodeFixProvider.cs
@@ -52,8 +52,8 @@ namespace Flow.Launcher.Localization.Analyzers.Localize
             if (root is null) return context.Document;
 
             var invocationExpr = root
-                ?.FindToken(diagnosticSpan.Start).Parent
-                ?.AncestorsAndSelf()
+                .FindToken(diagnosticSpan.Start).Parent
+                .AncestorsAndSelf()
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault();
 


### PR DESCRIPTION
> [!IMPORTANT]
> I have thoroughly tested the generator diagnostics and code fixes related to the old translation and I believe them are ready to move to production.

# Support string.Format culture info parameter analyzer & code fixer

# Test

Now fixing them can work well.

```
_ = Context.API.GetTranslation("flowlauncher_plugin_localization_demo_plugin_name");
_ = API.GetTranslation("flowlauncher_plugin_localization_demo_plugin_name");

_ = string.Format(Context.API.GetTranslation("flowlauncher_plugin_localization_demo_plugin_used"), string.Empty, null, string.Empty);
_ = string.Format(API.GetTranslation("flowlauncher_plugin_localization_demo_plugin_used"), string.Empty, null, string.Empty);

_ = string.Format(CultureInfo.CurrentCulture, Context.API.GetTranslation("flowlauncher_plugin_localization_demo_plugin_used"), string.Empty, null, string.Empty);
_ = string.Format(CultureInfo.CurrentCulture, API.GetTranslation("flowlauncher_plugin_localization_demo_plugin_used"), string.Empty, null, string.Empty);
```