### PR TITLE
Use Microsoft.CodeAnalysis.CSharp 4.12.0 to fix appveyor build error

### DIFF
--- a/Flow.Launcher.Localization.Analyzers/Flow.Launcher.Localization.Analyzers.csproj
+++ b/Flow.Launcher.Localization.Analyzers/Flow.Launcher.Localization.Analyzers.csproj
@@ -11,8 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Flow.Launcher.Localization.Shared/Flow.Launcher.Localization.Shared.csproj
+++ b/Flow.Launcher.Localization.Shared/Flow.Launcher.Localization.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
   </ItemGroup>
 
 </Project>

--- a/Flow.Launcher.Localization.SourceGenerators/Flow.Launcher.Localization.SourceGenerators.csproj
+++ b/Flow.Launcher.Localization.SourceGenerators/Flow.Launcher.Localization.SourceGenerators.csproj
@@ -13,7 +13,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Flow.Launcher.Localization/Flow.Launcher.Localization.csproj
+++ b/Flow.Launcher.Localization/Flow.Launcher.Localization.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.0.3</Version>
-    <PackageVersion>0.0.3</PackageVersion>
-    <AssemblyVersion>0.0.3</AssemblyVersion>
-    <FileVersion>0.0.3</FileVersion>
+    <Version>0.0.4</Version>
+    <PackageVersion>0.0.4</PackageVersion>
+    <AssemblyVersion>0.0.4</AssemblyVersion>
+    <FileVersion>0.0.4</FileVersion>
     <PackageId>Flow.Launcher.Localization</PackageId>
     <Title>Flow Launcher Localization Toolkit</Title>
     <Description>Localization toolkit for Flow Launcher and its plugins</Description>


### PR DESCRIPTION
## Summary

Use `Microsoft.CodeAnalysis.CSharp 4.12.0` to fix the build error on https://github.com/Flow-Launcher/Flow.Launcher/pull/3765. Appveyor uses a lower VS version and we can't fix it on our side.

## Tests

https://github.com/Flow-Launcher/Flow.Launcher/pull/3870 builds.