### PR TITLE
Suppress warning for old localization API usage in generated codes

### DIFF
--- a/Flow.Launcher.Localization.Shared/Constants.cs
+++ b/Flow.Launcher.Localization.Shared/Constants.cs
@@ -28,6 +28,7 @@ namespace Flow.Launcher.Localization.Shared
         public const string PublicApiClassName = "PublicApi";
         public const string PublicApiPrivatePropertyName = "instance";
         public const string PublicApiInternalPropertyName = "Instance";
+        public const string SuppressWarning = "#pragma warning disable FLAN0001 // Old localization API used";
 
         public static readonly Regex LanguagesXamlRegex = new Regex(@"\\Languages\\[^\\]+\.xaml$", RegexOptions.IgnoreCase);
         public static readonly string[] OldLocalizationClasses = { "IPublicAPI", "Internationalization" };

--- a/Flow.Launcher.Localization.SourceGenerators/Localize/EnumSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/EnumSourceGenerator.cs
@@ -193,6 +193,10 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             sourceBuilder.AppendLine($"namespace {enumNamespace};");
             sourceBuilder.AppendLine();
 
+            // Suppress warning for old localization API usage
+            sourceBuilder.AppendLine(Constants.SuppressWarning);
+            sourceBuilder.AppendLine();
+
             // Generate class
             sourceBuilder.AppendLine($"/// <summary>");
             sourceBuilder.AppendLine($"/// Data class for <see cref=\"{enumFullName}\"/>");

--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -473,6 +473,10 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             sourceBuilder.AppendLine($"namespace {assemblyNamespace};");
             sourceBuilder.AppendLine();
 
+            // Suppress warning for old localization API usage
+            sourceBuilder.AppendLine(Constants.SuppressWarning);
+            sourceBuilder.AppendLine();
+
             // Uncomment them for debugging
             //sourceBuilder.AppendLine("/*");
             /*// Generate all localization strings


### PR DESCRIPTION
In generated codes, we should not check old localization API usage warning.