### PR TITLE
Fix issue that strings with parameters are not parsed automatically

### DIFF
--- a/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
+++ b/Flow.Launcher.Localization.SourceGenerators/Localize/LocalizeSourceGenerator.cs
@@ -24,7 +24,6 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
         private static readonly Version PackageVersion = typeof(LocalizeSourceGenerator).Assembly.GetName().Version;
 
         private static readonly ImmutableArray<LocalizableString> _emptyLocalizableStrings = ImmutableArray<LocalizableString>.Empty;
-        private static readonly ImmutableArray<LocalizableStringParam> _emptyLocalizableStringParams = ImmutableArray<LocalizableStringParam>.Empty;
 
         #endregion
 
@@ -355,7 +354,8 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
         {
             if (comment == null || comment.Value == null || parameters.Count == 0)
             {
-                return (null, _emptyLocalizableStringParams);
+                // If the comment is not a valid XML, the summary is null and the parameters are not updated
+                return (null, parameters.ToImmutableArray());
             }
 
             try
@@ -385,7 +385,8 @@ namespace Flow.Launcher.Localization.SourceGenerators.Localize
             }
             catch
             {
-                return (null, _emptyLocalizableStringParams);
+                // If the comment is not a valid XML, the summary is null and the parameters are not updated
+                return (null, parameters.ToImmutableArray());
             }
         }
 


### PR DESCRIPTION
# CHANGES

When comment of one localization string is empty, its parameters will be empty. So we should return the original parameters `parameters.ToImmutableArray()` instead of `_emptyLocalizableStringParams`.

# TEST

We have one localization strings with parameters:
```xml
<system:String x:Key="flowlauncher_plugin_localization_demo_plugin_unused2">This is an unused string with parameters {2:00}, {1,-35:D} and {0}!!</system:String>
```

Originally, the result is:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/6e11f78c-38e0-42c2-8834-50873fb3f475" />

Now, the result is:
<img width="1000" alt="Screenshot 2025-09-21 004912" src="https://github.com/user-attachments/assets/1c737275-6eb8-420a-b33b-f202a473f724" />